### PR TITLE
Add device diagnostics tab with environment summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
             <button class="tab-button" data-tab="counter-tool" role="tab" aria-selected="false" aria-controls="counter-tool">Word Counter</button>
             <button class="tab-button" data-tab="case-tool" role="tab" aria-selected="false" aria-controls="case-tool">Case Converter</button>
             <button class="tab-button" data-tab="clean-text" role="tab" aria-selected="false" aria-controls="clean-text">Clean Text</button>
+            <button class="tab-button" data-tab="device-info" role="tab" aria-selected="false" aria-controls="device-info">Device Details</button>
         </div>
 
         <!-- Display Resolution Tool -->
@@ -177,7 +178,53 @@
                 </div>
             </div>
         </div>
+
+        <!-- Device Details Tool -->
+        <div class="tool-panel" id="device-info">
+            <h2>Device Details</h2>
+            <p class="device-info-intro">Share this information when reporting issues so we can reproduce bugs faster.</p>
+            <div class="device-info-grid">
+                <div class="info-card">
+                    <h3>Browser</h3>
+                    <p id="browserName">—</p>
+                    <span class="info-subtext" id="browserVersion">Version: —</span>
+                </div>
+                <div class="info-card">
+                    <h3>Operating System</h3>
+                    <p id="osName">—</p>
+                    <span class="info-subtext" id="deviceType">Device: —</span>
+                </div>
+                <div class="info-card">
+                    <h3>Platform</h3>
+                    <p id="platformInfo">—</p>
+                    <span class="info-subtext" id="hardwareConcurrency">CPU: —</span>
+                </div>
+                <div class="info-card">
+                    <h3>Memory</h3>
+                    <p id="deviceMemory">—</p>
+                    <span class="info-subtext" id="language">Language: —</span>
+                </div>
+                <div class="info-card">
+                    <h3>Screen Resolution</h3>
+                    <p id="deviceScreenResolution">—</p>
+                    <span class="info-subtext" id="pixelRatio">Pixel Ratio: —</span>
+                </div>
+                <div class="info-card">
+                    <h3>Viewport Size</h3>
+                    <p id="viewportSize">—</p>
+                    <span class="info-subtext" id="timeZone">Time Zone: —</span>
+                </div>
+            </div>
+            <div class="user-agent-section">
+                <h3>User Agent</h3>
+                <pre id="userAgent" class="user-agent-box" aria-live="polite">—</pre>
+            </div>
+            <div class="device-actions">
+                <button id="copyDeviceDetails" class="action-btn">Copy Device Summary</button>
+            </div>
+        </div>
+        <footer class="dashboard-footer" aria-label="Application version">Version 0.3 Nov</footer>
     </div>
     <script src="script.js"></script>
 </body>
-</html> 
+</html>

--- a/script.js
+++ b/script.js
@@ -21,6 +21,24 @@ document.getElementById('theme-switcher').addEventListener('click', toggleTheme)
 const tabButtons = document.querySelectorAll('.tab-button');
 const toolPanels = document.querySelectorAll('.tool-panel');
 
+// Device details elements
+const deviceInfoElements = {
+    browserName: document.getElementById('browserName'),
+    browserVersion: document.getElementById('browserVersion'),
+    osName: document.getElementById('osName'),
+    deviceType: document.getElementById('deviceType'),
+    platformInfo: document.getElementById('platformInfo'),
+    hardwareConcurrency: document.getElementById('hardwareConcurrency'),
+    deviceMemory: document.getElementById('deviceMemory'),
+    language: document.getElementById('language'),
+    deviceScreenResolution: document.getElementById('deviceScreenResolution'),
+    pixelRatio: document.getElementById('pixelRatio'),
+    viewportSize: document.getElementById('viewportSize'),
+    timeZone: document.getElementById('timeZone'),
+    userAgent: document.getElementById('userAgent')
+};
+const copyDeviceDetailsButton = document.getElementById('copyDeviceDetails');
+
 tabButtons.forEach(button => {
     button.addEventListener('click', () => {
         // Remove active class from all buttons and panels
@@ -46,6 +64,171 @@ function getDisplayScale() {
     const devicePixelRatio = window.devicePixelRatio;
     const scalePercentage = Math.round(devicePixelRatio * 100 / 25) * 25;
     return scalePercentage;
+}
+
+function detectBrowser(userAgent = navigator.userAgent) {
+    let name = 'Unknown';
+    let version = 'Unknown';
+
+    if (/Edg\//.test(userAgent)) {
+        name = 'Microsoft Edge';
+        version = userAgent.match(/Edg\/([\d.]+)/)[1];
+    } else if (/OPR\//.test(userAgent)) {
+        name = 'Opera';
+        version = userAgent.match(/OPR\/([\d.]+)/)[1];
+    } else if (/Brave\//.test(userAgent)) {
+        name = 'Brave';
+        version = userAgent.match(/Brave\/([\d.]+)/)[1];
+    } else if (/CriOS\//.test(userAgent)) {
+        name = 'Chrome (iOS)';
+        version = userAgent.match(/CriOS\/([\d.]+)/)[1];
+    } else if (/FxiOS\//.test(userAgent)) {
+        name = 'Firefox (iOS)';
+        version = userAgent.match(/FxiOS\/([\d.]+)/)[1];
+    } else if (/Chrome\//.test(userAgent) && !/Chromium/.test(userAgent)) {
+        name = 'Chrome';
+        version = userAgent.match(/Chrome\/([\d.]+)/)[1];
+    } else if (/Safari\//.test(userAgent) && /Version\//.test(userAgent)) {
+        name = 'Safari';
+        version = userAgent.match(/Version\/([\d.]+)/)[1];
+    } else if (/Firefox\//.test(userAgent)) {
+        name = 'Firefox';
+        version = userAgent.match(/Firefox\/([\d.]+)/)[1];
+    } else if (/MSIE\s([\d.]+)/.test(userAgent)) {
+        name = 'Internet Explorer';
+        version = userAgent.match(/MSIE\s([\d.]+)/)[1];
+    } else if (/Trident\/.*rv:([\d.]+)/.test(userAgent)) {
+        name = 'Internet Explorer';
+        version = userAgent.match(/Trident\/.*rv:([\d.]+)/)[1];
+    }
+
+    return { name, version };
+}
+
+function detectOS(userAgent = navigator.userAgent) {
+    if (/Windows NT 10\.0/.test(userAgent)) return 'Windows 10/11';
+    if (/Windows NT 6\.3/.test(userAgent)) return 'Windows 8.1';
+    if (/Windows NT 6\.2/.test(userAgent)) return 'Windows 8';
+    if (/Windows NT 6\.1/.test(userAgent)) return 'Windows 7';
+    if (/Mac OS X (10[._]\d+[._]?\d*)/.test(userAgent)) {
+        return `macOS ${userAgent.match(/Mac OS X (10[._]\d+[._]?\d*)/)[1].replace(/_/g, '.')}`;
+    }
+    if (/Mac OS X/.test(userAgent)) return 'macOS';
+    if (/iPhone|iPad|iPod/.test(userAgent)) return 'iOS';
+    if (/Android/.test(userAgent)) return 'Android';
+    if (/CrOS/.test(userAgent)) return 'Chrome OS';
+    if (/Linux/.test(userAgent)) return 'Linux';
+    return 'Unknown';
+}
+
+function getDeviceType(userAgent = navigator.userAgent) {
+    const isMobile = navigator.userAgentData?.mobile ?? /Mobi|Android/i.test(userAgent);
+    if (isMobile) return 'Mobile';
+    if (/Tablet|iPad/i.test(userAgent)) return 'Tablet';
+    return 'Desktop';
+}
+
+function formatMemory(memory) {
+    if (typeof memory !== 'number' || Number.isNaN(memory)) {
+        return 'Unavailable';
+    }
+    if (memory < 1) {
+        return `${Math.round(memory * 1024)} MB`;
+    }
+    return `${memory} GB`;
+}
+
+function getPreferredLanguages() {
+    if (Array.isArray(navigator.languages) && navigator.languages.length > 0) {
+        const [primary, ...rest] = navigator.languages;
+        return rest.length > 0 ? `${primary} (Preferred: ${navigator.languages.join(', ')})` : primary;
+    }
+    return navigator.language || 'Unavailable';
+}
+
+function updateDeviceDetails() {
+    if (!deviceInfoElements.browserName) {
+        return;
+    }
+
+    const { name, version } = detectBrowser();
+    const operatingSystem = detectOS();
+    const deviceType = getDeviceType();
+    const platform = navigator.userAgentData?.platform || navigator.platform || 'Unavailable';
+    const hardware = typeof navigator.hardwareConcurrency === 'number'
+        ? `${navigator.hardwareConcurrency} logical cores`
+        : 'Unavailable';
+    const memory = formatMemory(navigator.deviceMemory);
+    const languages = getPreferredLanguages();
+    const pixelRatio = window.devicePixelRatio ? window.devicePixelRatio.toFixed(2) : '1';
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Unavailable';
+    const viewport = `${window.innerWidth} x ${window.innerHeight}`;
+    const screenResolution = `${window.screen.width} x ${window.screen.height}`;
+
+    deviceInfoElements.browserName.textContent = name;
+    deviceInfoElements.browserVersion.textContent = version !== 'Unknown'
+        ? `Version: ${version}`
+        : 'Version: Unavailable';
+    deviceInfoElements.osName.textContent = operatingSystem;
+    deviceInfoElements.deviceType.textContent = `Device: ${deviceType}`;
+    deviceInfoElements.platformInfo.textContent = platform;
+    deviceInfoElements.hardwareConcurrency.textContent = hardware !== 'Unavailable'
+        ? `CPU: ${hardware}`
+        : 'CPU: Unavailable';
+    deviceInfoElements.deviceMemory.textContent = memory;
+    deviceInfoElements.language.textContent = `Language: ${languages}`;
+    deviceInfoElements.deviceScreenResolution.textContent = `${screenResolution} (CSS pixels)`;
+    deviceInfoElements.pixelRatio.textContent = `Pixel Ratio: ${pixelRatio}`;
+    deviceInfoElements.viewportSize.textContent = viewport;
+    deviceInfoElements.timeZone.textContent = `Time Zone: ${timeZone}`;
+    deviceInfoElements.userAgent.textContent = navigator.userAgent;
+}
+
+function buildDeviceSummary() {
+    const { name, version } = detectBrowser();
+    const operatingSystem = detectOS();
+    const deviceType = getDeviceType();
+    const platform = navigator.userAgentData?.platform || navigator.platform || 'Unavailable';
+    const hardware = typeof navigator.hardwareConcurrency === 'number'
+        ? `${navigator.hardwareConcurrency} logical cores`
+        : 'Unavailable';
+    const memory = formatMemory(navigator.deviceMemory);
+    const languages = getPreferredLanguages();
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Unavailable';
+    const screenResolution = `${window.screen.width} x ${window.screen.height}`;
+    const viewport = `${window.innerWidth} x ${window.innerHeight}`;
+    const pixelRatio = window.devicePixelRatio ? window.devicePixelRatio.toFixed(2) : '1';
+    const vendor = navigator.vendor || 'Unavailable';
+    const cookieStatus = typeof navigator.cookieEnabled === 'boolean'
+        ? (navigator.cookieEnabled ? 'Yes' : 'No')
+        : 'Unavailable';
+    const brandVersions = navigator.userAgentData?.brands
+        ?.map(brand => `${brand.brand} ${brand.version}`)
+        .join(', ');
+
+    const summaryLines = [
+        `Browser: ${name}`,
+        `Browser Version: ${version}`,
+        `Vendor: ${vendor}`,
+        `Operating System: ${operatingSystem}`,
+        `Device Type: ${deviceType}`,
+        `Platform: ${platform}`,
+        `Hardware Concurrency: ${hardware}`,
+        `Memory: ${memory}`,
+        `Languages: ${languages}`,
+        `Time Zone: ${timeZone}`,
+        `Screen Resolution: ${screenResolution}`,
+        `Viewport Size: ${viewport}`,
+        `Device Pixel Ratio: ${pixelRatio}`,
+        `Cookies Enabled: ${cookieStatus}`,
+        `User Agent: ${navigator.userAgent}`
+    ];
+
+    if (brandVersions) {
+        summaryLines.splice(3, 0, `Brand Versions: ${brandVersions}`);
+    }
+
+    return summaryLines.join('\n');
 }
 
 // Function to update window size
@@ -81,10 +264,12 @@ function updateWindowSize() {
     if (displayScaleElement.dataset.lastScale !== scale.toString()) {
         displayScaleElement.parentElement.classList.add('highlight');
         setTimeout(() => {
-            displayScaleElement.parentElement.classList.remove('highlight');
-        }, 300);
+        displayScaleElement.parentElement.classList.remove('highlight');
+    }, 300);
         displayScaleElement.dataset.lastScale = scale.toString();
     }
+
+    updateDeviceDetails();
 }
 
 // Character Counter Tool
@@ -427,10 +612,11 @@ window.addEventListener('resize', handleResize);
 // Copy to clipboard functionality with error handling
 async function copyToClipboard(text, button) {
     if (text.trim() === '') return;
-    
+
+    const originalText = button.textContent;
+
     try {
         await navigator.clipboard.writeText(text);
-        const originalText = button.textContent;
         button.textContent = 'Copied!';
         setTimeout(() => {
             button.textContent = originalText;
@@ -449,6 +635,13 @@ copyCleanText.addEventListener('click', async () => {
     const text = cleanTextArea.value;
     await copyToClipboard(text, copyCleanText);
 });
+
+if (copyDeviceDetailsButton) {
+    copyDeviceDetailsButton.addEventListener('click', async () => {
+        const summary = buildDeviceSummary();
+        await copyToClipboard(summary, copyDeviceDetailsButton);
+    });
+}
 
 // Toggle text wrapping
 wrapTextButton.addEventListener('click', () => {
@@ -472,4 +665,4 @@ initializeEditor();
 clearCleanText.addEventListener('click', () => {
     cleanTextArea.value = '';
     initializeEditor();
-}); 
+});

--- a/styles.css
+++ b/styles.css
@@ -124,7 +124,7 @@ h2 {
 }
 
 /* Tool Panels */
-.tool-panel {
+.tool-panel { 
     display: none;
     opacity: 0;
     transition: opacity 0.3s ease;
@@ -176,6 +176,80 @@ h2 {
     color: var(--accent-color);
     font-size: 1.5rem;
     font-weight: bold;
+}
+
+/* Device Details Tool */
+.device-info-intro {
+    color: var(--text-secondary);
+    margin-bottom: 1.5rem;
+}
+
+.device-info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.info-card {
+    background: var(--bg-secondary);
+    padding: 1.5rem;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-height: 150px;
+}
+
+.info-card h3 {
+    color: var(--text-primary);
+    font-size: 1.1rem;
+}
+
+.info-card p {
+    color: var(--accent-color);
+    font-size: 1.3rem;
+    font-weight: 600;
+    word-break: break-word;
+}
+
+.info-subtext {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.user-agent-section h3 {
+    color: var(--text-primary);
+    margin-bottom: 0.75rem;
+}
+
+.user-agent-box {
+    background: var(--bg-secondary);
+    border-radius: 10px;
+    padding: 1rem;
+    font-family: 'Fira Code', 'Courier New', Courier, monospace;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    overflow-x: auto;
+    margin-bottom: 1.5rem;
+}
+
+.device-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.device-actions .action-btn {
+    width: auto;
+    padding: 0.75rem 1.5rem;
+}
+
+/* Footer */
+.dashboard-footer {
+    margin-top: 1.5rem;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
 }
 
 /* Character Counter Tool */


### PR DESCRIPTION
## Summary
- add a Device Details tab that surfaces browser, OS, and viewport data for faster bug triage
- enable copying a pre-formatted environment summary alongside user agent details
- display the new "Version 0.3 Nov" footer on the dashboard

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_6904816dbda48325b933c8862be74a6d