### PR TITLE
Add ffmpeg video compressor tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A collection of useful web tools including Display Resolution Tool, Character Co
 - 📱 Display Resolution Tool
 - ✍️ Character Counter
 - 🔤 Case Converter
+- 🎬 Image / Video Compressor (ffmpeg.wasm presets)
 - 🌓 Dark/Light Theme Support
 
 ## Usage
@@ -29,6 +30,11 @@ npx serve
 ```
 
 Then open `http://localhost:8000` in your browser.
+
+## Versioning
+
+- **v1.1.0** – Added the Image / Video Compressor located at [`/video-compressor/`](video-compressor/) with MP4→MP4 and MP4→WebM presets powered by `ffmpeg.wasm`.
+- **v1.0.0** – Initial release of the dashboard utilities.
 
 
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,16 @@
 <body>
     <div class="dashboard-container">
         <h1>Web Tools Dashboard</h1>
-        
+
+        <section class="new-tool-banner" aria-label="New tool announcement">
+            <div>
+                <p class="eyebrow">New in this release</p>
+                <h2>Image / Video Compressor (ffmpeg.wasm)</h2>
+                <p>Compress MP4 files right in the browser with ready-made presets. Works best for clips up to ~500&nbsp;MB.</p>
+            </div>
+            <a class="open-tool-link" href="video-compressor/">Open Tool →</a>
+        </section>
+
         <!-- Theme Switcher -->
         <button id="theme-switcher" class="theme-switcher" aria-label="Toggle dark/light theme">
             <span class="light-icon" aria-hidden="true">🌞</span>

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,55 @@ h1 {
     font-size: 2rem;
 }
 
+.new-tool-banner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    background: linear-gradient(120deg, #ec4899, #8b5cf6);
+    color: #fff;
+    border-radius: 16px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 10px 35px rgba(139, 92, 246, 0.3);
+}
+
+.new-tool-banner h2 {
+    margin: 0.25rem 0;
+    font-size: 1.4rem;
+}
+
+.new-tool-banner p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.open-tool-link {
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    text-decoration: none;
+    padding: 0.85rem 1.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+    transition: background 0.3s ease, transform 0.3s ease;
+    white-space: nowrap;
+}
+
+.open-tool-link:hover,
+.open-tool-link:focus-visible {
+    background: rgba(255, 255, 255, 0.3);
+    transform: translateY(-1px);
+}
+
 h2 {
     color: var(--text-primary);
     margin-bottom: 1.5rem;

--- a/video-compressor/index.html
+++ b/video-compressor/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Compress MP4 videos directly in the browser with ffmpeg.wasm presets.">
+    <title>Image / Video Compressor · ffmpeg.wasm</title>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+</head>
+<body>
+    <div class="compressor-wrapper">
+        <header class="compressor-header">
+            <a class="back-link" href="../">← Back to Web Tools Dashboard</a>
+            <h1>Image / Video Compressor</h1>
+            <p class="subtitle">MP4 → MP4 or MP4 → WebM directly in your browser powered by ffmpeg.wasm.</p>
+        </header>
+
+        <main class="compressor-main">
+            <section class="flow-grid">
+                <article class="flow-card">
+                    <div class="step-label">1</div>
+                    <h2>Upload MP4</h2>
+                    <label class="upload-zone" for="videoInput">
+                        <input type="file" id="videoInput" accept="video/mp4" hidden>
+                        <span>Drop a file here or click to browse</span>
+                        <small>Only MP4 inputs are supported right now.</small>
+                    </label>
+                    <p id="fileDetails" class="muted">No file selected.</p>
+                </article>
+
+                <article class="flow-card">
+                    <div class="step-label">2</div>
+                    <h2>Choose Preset</h2>
+                    <label class="field">
+                        <span class="field-label">Compression preset</span>
+                        <select id="presetSelect">
+                            <option value="mp4-small">MP4 → MP4 · Small file (CRF 28, veryfast)</option>
+                            <option value="webm">MP4 → WebM · Efficient (CRF 35, VP9 + Opus)</option>
+                        </select>
+                    </label>
+                    <p class="muted">We focus on two simple scenarios to keep the experience fast and predictable.</p>
+                </article>
+
+                <article class="flow-card">
+                    <div class="step-label">3</div>
+                    <h2>Compress</h2>
+                    <div class="engine-actions">
+                        <button id="prepareEngineBtn" type="button">Load FFmpeg Engine</button>
+                        <button id="compressBtn" type="button">Compress</button>
+                    </div>
+                    <div class="engine-status" aria-live="polite">
+                        <div class="spinner" id="engineSpinner" aria-hidden="true"></div>
+                        <p id="statusMessage">Engine idle. We will load ffmpeg.wasm (~25-30&nbsp;MB) on demand.</p>
+                    </div>
+                    <div class="progress-wrapper">
+                        <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                            <span id="progressFill"></span>
+                        </div>
+                        <span id="progressText">0%</span>
+                    </div>
+                    <div class="log-panel">
+                        <div class="log-header">
+                            <h3>Activity log</h3>
+                            <button id="clearLogBtn" type="button">Clear</button>
+                        </div>
+                        <ul id="logList" aria-live="polite"></ul>
+                    </div>
+                </article>
+
+                <article class="flow-card">
+                    <div class="step-label">4</div>
+                    <h2>Download</h2>
+                    <button id="downloadBtn" type="button" disabled>Download result</button>
+                    <p id="resultSummary" class="muted">The button will unlock after a successful run.</p>
+                </article>
+            </section>
+
+            <section class="limitations">
+                <h2>Practical limitations</h2>
+                <ul>
+                    <li>Browser-based compression works best with clips up to ~300–500&nbsp;MB.</li>
+                    <li>Expect longer processing times on mobile devices or older laptops.</li>
+                    <li>The tab must stay open while the conversion is running.</li>
+                    <li>We currently support MP4 inputs with two ready-made presets (MP4 output or optional WebM).</li>
+                </ul>
+            </section>
+        </main>
+    </div>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/video-compressor/script.js
+++ b/video-compressor/script.js
@@ -1,0 +1,229 @@
+import { createFFmpeg, fetchFile } from 'https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.6/+esm';
+
+const videoInput = document.getElementById('videoInput');
+const presetSelect = document.getElementById('presetSelect');
+const prepareEngineBtn = document.getElementById('prepareEngineBtn');
+const compressBtn = document.getElementById('compressBtn');
+const downloadBtn = document.getElementById('downloadBtn');
+const statusMessage = document.getElementById('statusMessage');
+const spinner = document.getElementById('engineSpinner');
+const progressFill = document.getElementById('progressFill');
+const progressBar = document.querySelector('.progress-bar');
+const progressText = document.getElementById('progressText');
+const logList = document.getElementById('logList');
+const clearLogBtn = document.getElementById('clearLogBtn');
+const fileDetails = document.getElementById('fileDetails');
+const resultSummary = document.getElementById('resultSummary');
+
+let ffmpeg;
+let outputUrl = '';
+let lastInputSize = 0;
+
+function formatBytes(bytes) {
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / Math.pow(1024, exponent);
+    return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+function setStatus(message) {
+    statusMessage.textContent = message;
+}
+
+function toggleSpinner(show, message) {
+    spinner.classList.toggle('active', show);
+    if (message) {
+        setStatus(message);
+    }
+}
+
+function resetProgress() {
+    progressFill.style.width = '0%';
+    progressText.textContent = '0%';
+    progressBar.setAttribute('aria-valuenow', '0');
+}
+
+function updateProgress(ratio) {
+    const percentage = Math.min(100, Math.round(ratio * 100));
+    progressFill.style.width = `${percentage}%`;
+    progressText.textContent = `${percentage}%`;
+    progressBar.setAttribute('aria-valuenow', String(percentage));
+}
+
+function addLog(message) {
+    if (!message?.trim()) return;
+    const item = document.createElement('li');
+    item.textContent = message;
+    logList.appendChild(item);
+    while (logList.children.length > 8) {
+        logList.removeChild(logList.firstChild);
+    }
+    logList.scrollTop = logList.scrollHeight;
+}
+
+function clearLog() {
+    logList.innerHTML = '';
+}
+
+function revokeOutputUrl() {
+    if (outputUrl) {
+        URL.revokeObjectURL(outputUrl);
+        outputUrl = '';
+    }
+}
+
+async function ensureFfmpeg() {
+    if (!ffmpeg) {
+        ffmpeg = createFFmpeg({ log: true });
+        ffmpeg.setLogger(({ message }) => addLog(message));
+        ffmpeg.setProgress(({ ratio }) => updateProgress(ratio));
+    }
+
+    if (!ffmpeg.isLoaded()) {
+        toggleSpinner(true, 'Loading ffmpeg.wasm engine…');
+        prepareEngineBtn.disabled = true;
+        compressBtn.disabled = true;
+        try {
+            await ffmpeg.load();
+            setStatus('Engine ready. Select a file and hit Compress.');
+        } finally {
+            toggleSpinner(false);
+            prepareEngineBtn.disabled = false;
+            compressBtn.disabled = false;
+        }
+    }
+
+    return ffmpeg;
+}
+
+function describeFile(file) {
+    if (!file) {
+        fileDetails.textContent = 'No file selected.';
+        return;
+    }
+    fileDetails.innerHTML = `${file.name} · ${formatBytes(file.size)}`;
+    lastInputSize = file.size;
+}
+
+videoInput.addEventListener('change', (event) => {
+    const [file] = event.target.files || [];
+    describeFile(file);
+});
+
+prepareEngineBtn.addEventListener('click', () => {
+    ensureFfmpeg().catch(error => {
+        console.error(error);
+        setStatus('Unable to load ffmpeg.wasm. Please retry or refresh.');
+    });
+});
+
+clearLogBtn.addEventListener('click', clearLog);
+
+downloadBtn.addEventListener('click', () => {
+    if (!outputUrl) return;
+    const link = document.createElement('a');
+    link.href = outputUrl;
+    link.download = resultSummary.dataset.filename || 'compressed-video';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+});
+
+async function compress() {
+    const file = videoInput.files[0];
+    if (!file) {
+        setStatus('Please choose an MP4 file first.');
+        return;
+    }
+
+    if (file.type !== 'video/mp4') {
+        setStatus('Only MP4 inputs are supported at the moment.');
+        return;
+    }
+
+    const preset = presetSelect.value;
+    const ffmpegInstance = await ensureFfmpeg();
+
+    resetProgress();
+    toggleSpinner(true, 'Compressing… keep this tab open.');
+    prepareEngineBtn.disabled = true;
+    compressBtn.disabled = true;
+    downloadBtn.disabled = true;
+    revokeOutputUrl();
+    resultSummary.textContent = 'Running…';
+
+    try {
+        addLog(`Input: ${file.name}`);
+        ffmpegInstance.FS('writeFile', 'input.mp4', await fetchFile(file));
+
+        const mp4Args = ['-i', 'input.mp4', '-vcodec', 'libx264', '-crf', '28', '-preset', 'veryfast', '-movflags', '+faststart', '-acodec', 'aac', '-b:a', '96k', 'output.mp4'];
+        const webmArgs = ['-i', 'input.mp4', '-c:v', 'libvpx-vp9', '-b:v', '0', '-crf', '35', '-c:a', 'libopus', '-b:a', '96k', 'output.webm'];
+        const args = preset === 'webm' ? webmArgs : mp4Args;
+        const outputName = preset === 'webm' ? 'output.webm' : 'output.mp4';
+        const mime = preset === 'webm' ? 'video/webm' : 'video/mp4';
+
+        addLog(`Running preset: ${preset}`);
+        await ffmpegInstance.run(...args);
+
+        const data = ffmpegInstance.FS('readFile', outputName);
+        const blob = new Blob([data.buffer], { type: mime });
+        outputUrl = URL.createObjectURL(blob);
+        downloadBtn.disabled = false;
+        const humanReadable = formatBytes(data.length);
+        resultSummary.textContent = `Done: ${formatBytes(lastInputSize)} → ${humanReadable}`;
+        resultSummary.dataset.filename = `compressed-${preset}.${preset === 'webm' ? 'webm' : 'mp4'}`;
+        setStatus('Compression finished. You can download the file.');
+
+        ffmpegInstance.FS('unlink', 'input.mp4');
+        ffmpegInstance.FS('unlink', outputName);
+    } catch (error) {
+        console.error(error);
+        setStatus('Compression failed. Check the log and try again.');
+        addLog(`Error: ${error.message}`);
+    } finally {
+        toggleSpinner(false);
+        prepareEngineBtn.disabled = false;
+        compressBtn.disabled = false;
+    }
+}
+
+compressBtn.addEventListener('click', () => {
+    compress().catch(error => {
+        console.error(error);
+        setStatus('Unexpected error during compression.');
+        addLog(`Error: ${error.message}`);
+        toggleSpinner(false);
+        prepareEngineBtn.disabled = false;
+        compressBtn.disabled = false;
+    });
+});
+
+// Drag & drop support
+const uploadZone = document.querySelector('.upload-zone');
+
+['dragenter', 'dragover'].forEach(eventName => {
+    uploadZone.addEventListener(eventName, (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        uploadZone.classList.add('drag-active');
+    });
+});
+
+['dragleave', 'drop'].forEach(eventName => {
+    uploadZone.addEventListener(eventName, (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        uploadZone.classList.remove('drag-active');
+    });
+});
+
+uploadZone.addEventListener('drop', (event) => {
+    const [file] = event.dataTransfer.files || [];
+    if (file) {
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(file);
+        videoInput.files = dataTransfer.files;
+        describeFile(file);
+    }
+});

--- a/video-compressor/styles.css
+++ b/video-compressor/styles.css
@@ -1,0 +1,312 @@
+:root {
+    font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    color: #0f172a;
+    background-color: #0b1120;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, rgba(79, 70, 229, 0.3), rgba(15, 23, 42, 1));
+    padding: 2rem 1rem 3rem;
+    color: #0f172a;
+}
+
+.compressor-wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+    background: #f8fafc;
+    border-radius: 24px;
+    padding: 2rem;
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.25);
+}
+
+.compressor-header {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: #6366f1;
+    text-decoration: none;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.back-link:hover,
+.back-link:focus-visible {
+    text-decoration: underline;
+}
+
+.compressor-header h1 {
+    margin: 0.5rem 0;
+    font-size: clamp(2rem, 4vw, 2.8rem);
+}
+
+.subtitle {
+    margin: 0;
+    color: #475569;
+}
+
+.compressor-main {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.flow-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+}
+
+.flow-card {
+    background: #fff;
+    border-radius: 18px;
+    padding: 1.5rem;
+    border: 1px solid #e2e8f0;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    position: relative;
+}
+
+.step-label {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    width: 36px;
+    height: 36px;
+    border-radius: 12px;
+    background: #eef2ff;
+    color: #4338ca;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.upload-zone {
+    border: 2px dashed #cbd5f5;
+    border-radius: 16px;
+    padding: 1.75rem;
+    text-align: center;
+    background: #f8fafc;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    color: #475569;
+}
+
+.upload-zone:hover,
+.upload-zone:focus-within {
+    border-color: #6366f1;
+    color: #312e81;
+}
+
+.upload-zone.drag-active {
+    border-color: #10b981;
+    background: #ecfdf5;
+    color: #065f46;
+}
+
+select,
+button {
+    font: inherit;
+}
+
+select {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid #cbd5f5;
+    background: #f8fafc;
+}
+
+.field-label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+}
+
+.engine-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.85rem 1.4rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+#prepareEngineBtn {
+    background: #e0e7ff;
+    color: #312e81;
+}
+
+#compressBtn {
+    background: #4338ca;
+    color: #fff;
+}
+
+#downloadBtn {
+    width: fit-content;
+    background: #059669;
+    color: #fff;
+}
+
+.engine-status {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.spinner {
+    width: 28px;
+    height: 28px;
+    border: 3px solid #e0e7ff;
+    border-top-color: #4338ca;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    display: none;
+}
+
+.spinner.active {
+    display: inline-flex;
+}
+
+.progress-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.progress-bar {
+    flex: 1;
+    height: 12px;
+    border-radius: 999px;
+    background: #e2e8f0;
+    position: relative;
+}
+
+.progress-bar span {
+    position: absolute;
+    inset: 0;
+    width: 0;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #6366f1, #a855f7);
+    transition: width 0.2s ease;
+}
+
+.log-panel {
+    background: #f8fafc;
+    border-radius: 14px;
+    padding: 1rem;
+    border: 1px solid #e2e8f0;
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+.log-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+#clearLogBtn {
+    background: transparent;
+    color: #64748b;
+    padding: 0.4rem 0.8rem;
+    border-radius: 999px;
+    border: 1px solid #cbd5f5;
+}
+
+#clearLogBtn:hover {
+    background: #e2e8f0;
+}
+
+#logList {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.85rem;
+    color: #1f2937;
+}
+
+#logList li {
+    padding: 0.4rem 0.5rem;
+    background: #fff;
+    border-radius: 8px;
+    border: 1px solid #e5e7eb;
+}
+
+.limitations {
+    background: #0f172a;
+    color: #e2e8f0;
+    border-radius: 20px;
+    padding: 1.75rem;
+    box-shadow: inset 0 0 40px rgba(15, 23, 42, 0.6);
+}
+
+.limitations h2 {
+    margin-top: 0;
+}
+
+.limitations ul {
+    margin: 0;
+    padding-left: 1.25rem;
+}
+
+.limitations li {
+    margin-bottom: 0.5rem;
+}
+
+.muted {
+    color: #64748b;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (max-width: 640px) {
+    .compressor-wrapper {
+        padding: 1.25rem;
+    }
+
+    .engine-status {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .progress-wrapper {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Image / Video Compressor page powered by ffmpeg.wasm with lazy loading, presets, and UI messaging
- highlight the new tool on the main dashboard and document it in the README with a version entry

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c96bc677c83258a2e4df04ee3c836)