### PR TITLE
Fix drop zone handling and cleanup download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A collection of useful web tools including Display Resolution Tool, Character Co
 - ✍️ Character Counter
 - 🔤 Case Converter
 - 🌓 Dark/Light Theme Support
+- 🎬 Image / Video Compressor (ffmpeg.wasm)
 
 ## Usage
 
@@ -29,6 +30,15 @@ npx serve
 ```
 
 Then open `http://localhost:8000` in your browser.
+
+## Video compressor quick start
+
+1. Open [`/video-compressor/`](./video-compressor/).
+2. Drop an mp4 file (recommended up to ~500 MB).
+3. Pick one of the ready-made presets (smaller mp4 or mp4 → webm).
+4. Click **Compress video** and keep the tab in the foreground while ffmpeg.wasm works.
+
+Compression is performed entirely in your browser, so large videos can take several minutes on low-power devices.
 
 
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,16 @@
 <body>
     <div class="dashboard-container">
         <h1>Web Tools Dashboard</h1>
-        
+
+        <section class="tool-banner" aria-label="New tool announcement">
+            <div>
+                <p class="badge">New in v1.1</p>
+                <h2>Image / Video Compressor</h2>
+                <p>Compress mp4 clips directly in your browser with ffmpeg.wasm presets. Works best for clips up to ~500&nbsp;MB.</p>
+            </div>
+            <a class="banner-link" href="video-compressor/">Open compressor →</a>
+        </section>
+
         <!-- Theme Switcher -->
         <button id="theme-switcher" class="theme-switcher" aria-label="Toggle dark/light theme">
             <span class="light-icon" aria-hidden="true">🌞</span>

--- a/styles.css
+++ b/styles.css
@@ -259,6 +259,50 @@ h2 {
     gap: 1.5rem;
 }
 
+.tool-banner {
+    background: linear-gradient(135deg, rgba(88, 114, 255, 0.12), rgba(88, 114, 255, 0.06));
+    border: 1px solid rgba(88, 114, 255, 0.3);
+    border-radius: 1.25rem;
+    padding: 1.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.tool-banner .badge {
+    display: inline-flex;
+    padding: 0.2rem 0.8rem;
+    border-radius: 999px;
+    background: rgba(88, 114, 255, 0.15);
+    color: var(--primary-color);
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+}
+
+.tool-banner h2 {
+    margin: 0;
+}
+
+.banner-link {
+    text-decoration: none;
+    font-weight: 600;
+    color: var(--primary-color);
+    background: #fff;
+    padding: 0.75rem 1.25rem;
+    border-radius: 999px;
+    border: 1px solid rgba(88, 114, 255, 0.3);
+    box-shadow: 0 10px 30px rgba(88, 114, 255, 0.2);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.banner-link:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 40px rgba(88, 114, 255, 0.25);
+}
+
 .input-area {
     width: 100%;
     margin-bottom: 1.5rem;

--- a/video-compressor/index.html
+++ b/video-compressor/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Lightweight in-browser video compressor powered by ffmpeg.wasm.">
+    <title>Video Compressor | LYMN Web Tools</title>
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎬</text></svg>">
+</head>
+<body class="video-compressor-page">
+    <div class="vc-container">
+        <header class="vc-header">
+            <a href="../" class="back-link">← Back to Dashboard</a>
+            <div>
+                <p class="version-label">Tool version 1.1</p>
+                <h1>Image / Video Compressor</h1>
+                <p class="intro">Compress mp4 clips right in your browser without uploading them anywhere. The tool uses ffmpeg.wasm and works best for clips up to ~300–500 MB.</p>
+            </div>
+        </header>
+
+        <main class="vc-main">
+            <section class="module-card" aria-label="Video selection">
+                <h2>1. Upload your mp4 file</h2>
+                <p class="hint">Supported input: mp4 (H.264 / HEVC). On older phones or laptops, compression may take a while.</p>
+                <div class="drop-area" id="dropZone" role="button" tabindex="0">
+                    <p class="drop-title">Drop video here or click to browse</p>
+                    <p class="drop-subtitle">Maximum recommended size ~500 MB</p>
+                    <input type="file" id="videoInput" accept="video/mp4" aria-label="Video input">
+                </div>
+                <p class="selected-file" id="selectedFile">No file selected.</p>
+            </section>
+
+            <section class="module-card" aria-label="Compression settings">
+                <h2>2. Choose preset</h2>
+                <form class="preset-list" id="presetForm">
+                    <label class="preset-option">
+                        <input type="radio" name="preset" value="mp4" checked>
+                        <div>
+                            <strong>Smaller MP4 (H.264)</strong>
+                            <p>Converts mp4 to mp4 with CRF 28 and "faster" preset. Keeps audio track.</p>
+                        </div>
+                    </label>
+                    <label class="preset-option">
+                        <input type="radio" name="preset" value="webm">
+                        <div>
+                            <strong>MP4 → WebM (VP9)</strong>
+                            <p>Produces VP9 + Opus WebM. Useful for browsers that prefer WebM.</p>
+                        </div>
+                    </label>
+                </form>
+                <p class="disclaimer">Tip: Use the MP4 preset for the fastest export. WebM looks great but takes longer.</p>
+            </section>
+
+            <section class="module-card" aria-label="Compression controls">
+                <h2>3. Compress</h2>
+                <div class="actions">
+                    <button id="startButton" class="primary">Compress video</button>
+                    <div class="engine-loader" id="engineLoader" aria-live="polite" hidden>
+                        <span class="spinner" aria-hidden="true"></span>
+                        <span>Загружаем движок…</span>
+                    </div>
+                </div>
+                <div class="progress-wrapper" aria-live="polite">
+                    <progress id="progressBar" value="0" max="1"></progress>
+                    <p id="progressLabel">Waiting for a file…</p>
+                </div>
+            </section>
+
+            <section class="module-card" aria-label="Result">
+                <h2>4. Download</h2>
+                <p id="resultMessage">Your compressed video will appear here.</p>
+                <a id="downloadLink" class="primary ghost" href="#" download hidden>Download result</a>
+            </section>
+
+            <section class="module-card limits" aria-label="Limitations">
+                <h2>Practical limits</h2>
+                <ul>
+                    <li>Works best with mp4 files under ~500 MB.</li>
+                    <li>Compression runs locally — keep the tab open.</li>
+                    <li>Phones and low-end laptops may take several minutes.</li>
+                    <li>While ffmpeg.wasm is loading, please wait for the spinner to finish.</li>
+                </ul>
+            </section>
+        </main>
+
+        <footer class="vc-footer">
+            <p>Powered by <code>ffmpeg.wasm</code>. No videos leave your browser.</p>
+        </footer>
+    </div>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/video-compressor/script.js
+++ b/video-compressor/script.js
@@ -1,0 +1,197 @@
+import { createFFmpeg, fetchFile } from 'https://unpkg.com/@ffmpeg/ffmpeg@0.12.4/dist/ffmpeg.min.js';
+
+const startButton = document.getElementById('startButton');
+const fileInput = document.getElementById('videoInput');
+const dropZone = document.getElementById('dropZone');
+const progressBar = document.getElementById('progressBar');
+const progressLabel = document.getElementById('progressLabel');
+const selectedFileLabel = document.getElementById('selectedFile');
+const engineLoader = document.getElementById('engineLoader');
+const downloadLink = document.getElementById('downloadLink');
+const resultMessage = document.getElementById('resultMessage');
+
+const ffmpeg = createFFmpeg({
+  log: true,
+  corePath: 'https://unpkg.com/@ffmpeg/core@0.12.4/dist/ffmpeg-core.js'
+});
+let currentFile = null;
+let isProcessing = false;
+let currentDownloadUrl = null;
+
+const revokeDownloadUrl = () => {
+  if (currentDownloadUrl) {
+    URL.revokeObjectURL(currentDownloadUrl);
+    currentDownloadUrl = null;
+  }
+};
+
+const readerFriendlySize = (size) => {
+  if (!size && size !== 0) return '';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let i = 0;
+  let value = size;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i += 1;
+  }
+  return `${value.toFixed(value >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+};
+
+const updateSelectedFile = () => {
+  if (currentFile) {
+    selectedFileLabel.textContent = `${currentFile.name} (${readerFriendlySize(currentFile.size)})`;
+    progressLabel.textContent = 'Ready to compress.';
+  } else {
+    selectedFileLabel.textContent = 'No file selected.';
+    progressLabel.textContent = 'Waiting for a file…';
+  }
+};
+
+const showEngineLoader = (show) => {
+  engineLoader.hidden = !show;
+};
+
+const ensureFFmpegLoaded = async () => {
+  if (!ffmpeg.isLoaded()) {
+    showEngineLoader(true);
+    progressLabel.textContent = 'Loading ffmpeg engine…';
+    await ffmpeg.load();
+    showEngineLoader(false);
+  }
+};
+
+const resetDownloadState = () => {
+  revokeDownloadUrl();
+  downloadLink.hidden = true;
+  downloadLink.removeAttribute('href');
+  downloadLink.removeAttribute('download');
+};
+
+const handleFiles = (files) => {
+  if (!files || files.length === 0) return;
+  const [file] = files;
+  const isMp4ByMime = file.type && file.type.includes('mp4');
+  const isMp4ByName = file.name?.toLowerCase().endsWith('.mp4');
+  if (!isMp4ByMime && !isMp4ByName) {
+    resultMessage.textContent = 'Only mp4 files are supported right now.';
+    return;
+  }
+  currentFile = file;
+  resetDownloadState();
+  updateSelectedFile();
+  // allow selecting the same file consecutively without needing to clear input manually
+  fileInput.value = '';
+};
+
+const getPreset = () => {
+  const form = document.getElementById('presetForm');
+  const formData = new FormData(form);
+  return formData.get('preset');
+};
+
+const runCompression = async () => {
+  if (!currentFile || isProcessing) {
+    resultMessage.textContent = currentFile ? 'Another compression is already running…' : 'Please choose a file first.';
+    return;
+  }
+
+  try {
+    isProcessing = true;
+    startButton.disabled = true;
+    resetDownloadState();
+    progressBar.value = 0;
+    progressLabel.textContent = 'Preparing…';
+
+    await ensureFFmpegLoaded();
+
+    ffmpeg.setProgress(({ ratio }) => {
+      if (Number.isFinite(ratio)) {
+        progressBar.value = ratio;
+        const percent = Math.min(100, Math.max(0, Math.round(ratio * 100)));
+        progressLabel.textContent = `Compressing… ${percent}%`;
+      }
+    });
+
+    const inputName = 'input.mp4';
+    const preset = getPreset();
+    const outputName = preset === 'webm' ? 'output.webm' : 'output.mp4';
+
+    ffmpeg.FS('writeFile', inputName, await fetchFile(currentFile));
+
+    const command = preset === 'webm'
+      ? ['-i', inputName, '-c:v', 'libvpx-vp9', '-b:v', '1.2M', '-crf', '32', '-deadline', 'good', '-c:a', 'libopus', outputName]
+      : ['-i', inputName, '-c:v', 'libx264', '-preset', 'faster', '-crf', '28', '-c:a', 'copy', outputName];
+
+    await ffmpeg.run(...command);
+
+    const data = ffmpeg.FS('readFile', outputName);
+    const mime = preset === 'webm' ? 'video/webm' : 'video/mp4';
+    const blob = new Blob([data.buffer], { type: mime });
+    const url = URL.createObjectURL(blob);
+    revokeDownloadUrl();
+    currentDownloadUrl = url;
+
+    downloadLink.href = url;
+    downloadLink.download = preset === 'webm' ? 'compressed.webm' : 'compressed.mp4';
+    downloadLink.hidden = false;
+    resultMessage.textContent = 'Done! Click the button below to download the compressed video.';
+    progressLabel.textContent = 'Complete ✅';
+  } catch (error) {
+    console.error(error);
+    resultMessage.textContent = 'Something went wrong while compressing the file. Please try again or refresh the page.';
+    progressLabel.textContent = 'Error';
+  } finally {
+    isProcessing = false;
+    startButton.disabled = false;
+    if (currentFile) {
+      ffmpeg.FS('unlink', 'input.mp4');
+      try {
+        ffmpeg.FS('unlink', 'output.mp4');
+      } catch (e) {}
+      try {
+        ffmpeg.FS('unlink', 'output.webm');
+      } catch (e) {}
+    }
+  }
+};
+
+startButton.addEventListener('click', runCompression);
+
+fileInput.addEventListener('change', (event) => handleFiles(event.target.files));
+
+dropZone.addEventListener('click', () => {
+  fileInput.click();
+});
+
+dropZone.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    fileInput.click();
+  }
+});
+
+dropZone.addEventListener('dragover', (event) => {
+  event.preventDefault();
+  dropZone.classList.add('dragover');
+});
+
+dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+
+dropZone.addEventListener('drop', (event) => {
+  event.preventDefault();
+  dropZone.classList.remove('dragover');
+  handleFiles(event.dataTransfer.files);
+});
+
+// Provide a button to kick off loading even before selecting a file
+startButton.addEventListener('pointerdown', () => {
+  if (!ffmpeg.isLoaded()) {
+    ensureFFmpegLoaded().catch(() => {
+      progressLabel.textContent = 'Unable to load ffmpeg. Check your connection and retry.';
+    });
+  }
+});
+
+window.addEventListener('beforeunload', revokeDownloadUrl);
+
+updateSelectedFile();

--- a/video-compressor/styles.css
+++ b/video-compressor/styles.css
@@ -1,0 +1,254 @@
+body.video-compressor-page {
+    margin: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 1.5rem;
+    gap: 1.5rem;
+}
+
+.video-compressor-page .vc-container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.vc-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
+.back-link {
+    text-decoration: none;
+    color: var(--accent-color);
+    font-weight: 600;
+}
+
+.version-label {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.vc-header h1 {
+    margin: 0;
+    font-size: clamp(1.8rem, 2vw, 2.4rem);
+}
+
+.vc-main {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.module-card {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.08);
+}
+
+.module-card h2 {
+    margin-top: 0;
+}
+
+.hint {
+    margin-top: -0.5rem;
+    color: var(--text-secondary);
+}
+
+.drop-area {
+    border: 2px dashed var(--border-color);
+    border-radius: 0.75rem;
+    padding: 2rem;
+    text-align: center;
+    position: relative;
+    background: var(--bg-secondary);
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+    outline: none;
+}
+
+.drop-area.dragover {
+    border-color: var(--accent-color);
+    background: rgba(0, 0, 0, 0.05);
+    background: color-mix(in srgb, var(--accent-color) 8%, transparent);
+}
+
+.drop-area:focus-visible {
+    box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-color) 20%, transparent);
+}
+
+.drop-title {
+    margin: 0;
+    font-weight: 600;
+}
+
+.drop-subtitle {
+    margin: 0.5rem 0 0;
+    color: var(--text-secondary);
+}
+
+#videoInput {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+    pointer-events: none;
+}
+
+.selected-file {
+    color: var(--text-secondary);
+    margin-top: 0.75rem;
+}
+
+.preset-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.preset-option {
+    display: flex;
+    gap: 0.75rem;
+    padding: 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 0.75rem;
+    cursor: pointer;
+}
+
+.preset-option input {
+    margin-top: 0.3rem;
+}
+
+.disclaimer {
+    color: var(--text-secondary);
+    margin-top: 1rem;
+}
+
+.primary {
+    background: var(--accent-color);
+    color: var(--bg-primary);
+    border: none;
+    padding: 0.85rem 1.5rem;
+    border-radius: 999px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.primary:hover {
+    background: var(--text-primary);
+}
+
+.primary.ghost {
+    background: transparent;
+    border: 1px solid var(--accent-color);
+    color: var(--accent-color);
+    text-align: center;
+    display: inline-block;
+}
+
+.actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.engine-loader {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+}
+
+.spinner {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: 3px solid rgba(0, 0, 0, 0.08);
+    border-top-color: var(--accent-color);
+    animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+progress {
+    width: 100%;
+    height: 12px;
+    border-radius: 999px;
+    overflow: hidden;
+    appearance: none;
+}
+
+progress::-webkit-progress-bar {
+    background: var(--bg-secondary);
+}
+
+progress::-webkit-progress-value {
+    background: var(--accent-color);
+}
+
+progress::-moz-progress-bar {
+    background: var(--accent-color);
+}
+
+.progress-wrapper {
+    margin-top: 1rem;
+}
+
+.limits {
+    background: var(--bg-secondary);
+}
+
+.vc-footer {
+    text-align: center;
+    color: var(--text-secondary);
+    margin-top: 2rem;
+}
+
+@media (max-width: 768px) {
+    body.video-compressor-page {
+        padding: 1.25rem;
+    }
+
+    .actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+.limits ul {
+    padding-left: 1.25rem;
+    margin: 0;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 600px) {
+    body.video-compressor-page {
+        padding: 1rem;
+    }
+
+    .primary {
+        width: 100%;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
## Summary
- visually hide the native file input so the drag-and-drop target can actually receive drops while remaining screen-reader accessible
- reset and revoke generated blob URLs before/after each compression so repeated exports don’t leak memory or reuse stale links
- clear download attributes and revoke object URLs on unload to keep the UI and browser state consistent

## Testing
- python -m http.server 8000

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c98b74de883258ea5f7e8154c8f16)