### PR TITLE
Remove video compressor link from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,15 +12,6 @@
     <div class="dashboard-container">
         <h1>Web Tools Dashboard</h1>
 
-        <section class="tool-banner" aria-label="New tool announcement">
-            <div>
-                <p class="badge">New in v1.1</p>
-                <h2>Image / Video Compressor</h2>
-                <p>Compress mp4 clips directly in your browser with ffmpeg.wasm presets. Works best for clips up to ~500&nbsp;MB.</p>
-            </div>
-            <a class="banner-link" href="video-compressor/">Open compressor →</a>
-        </section>
-
         <!-- Theme Switcher -->
         <button id="theme-switcher" class="theme-switcher" aria-label="Toggle dark/light theme">
             <span class="light-icon" aria-hidden="true">🌞</span>


### PR DESCRIPTION
## Summary
- remove the Image / Video Compressor announcement banner so the video service link is no longer visible on the home page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d81727094832585d945c815aa8410)