### PR TITLE
Fix ffmpeg core asset path for video compressor

### DIFF
--- a/video-compressor/script.js
+++ b/video-compressor/script.js
@@ -14,7 +14,7 @@ const uploadStatus = document.getElementById('uploadStatus');
 const uploadStatusText = document.getElementById('uploadStatusText');
 
 const CORE_VERSION = '0.12.4';
-const CORE_PATH = `https://unpkg.com/@ffmpeg/core@${CORE_VERSION}/dist/umd/ffmpeg-core.js`;
+const CORE_PATH = `https://unpkg.com/@ffmpeg/core@${CORE_VERSION}/dist/ffmpeg-core.js`;
 const ffmpeg = createFFmpeg({
   corePath: CORE_PATH,
 });


### PR DESCRIPTION
### Motivation
- ffmpeg.wasm failed to load and the UI hung on “Loading compression engine…” because core assets were requested from the wrong directory.
- The code pointed `corePath` to `/dist/umd/` while `ffmpeg-core.wasm` and `ffmpeg-core.worker.js` are served from `/dist/`.

### Description
- Updated the `CORE_PATH` constant in `video-compressor/script.js` to `https://unpkg.com/@ffmpeg/core@${CORE_VERSION}/dist/ffmpeg-core.js` so all core assets resolve correctly.
- The `createFFmpeg` invocation continues to pass `corePath: CORE_PATH` unchanged so runtime loading uses the corrected URL.
- Committed the change to the repository.

### Testing
- No automated tests were run for this change.
- CI or local test suites were not executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ee5aa0348325b44c947dfbf3d1d9)