### PR TITLE
Use local FFmpeg assets; remove COOP/COEP service worker

### DIFF
--- a/video-compressor/index.html
+++ b/video-compressor/index.html
@@ -92,7 +92,6 @@
         <p>Powered by <code>ffmpeg.wasm</code>. No videos leave your browser.</p>
     </footer>
 
-    <script src="../coi-serviceworker.js"></script>
     <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/video-compressor/script.js
+++ b/video-compressor/script.js
@@ -1,4 +1,4 @@
-import { createFFmpeg } from 'https://unpkg.com/@ffmpeg/ffmpeg@0.12.4/dist/ffmpeg.min.mjs';
+import { createFFmpeg } from './vendor/ffmpeg.min.mjs';
 
 const startButton = document.getElementById('startButton');
 const fileInput = document.getElementById('videoInput');
@@ -14,7 +14,7 @@ const uploadStatus = document.getElementById('uploadStatus');
 const uploadStatusText = document.getElementById('uploadStatusText');
 
 const CORE_VERSION = '0.12.4';
-const CORE_PATH = `https://unpkg.com/@ffmpeg/core@${CORE_VERSION}/dist/ffmpeg-core.js`;
+const CORE_PATH = './vendor/ffmpeg-core.js';
 const ffmpeg = createFFmpeg({
   corePath: CORE_PATH,
 });

--- a/video-compressor/vendor/ffmpeg-core.js
+++ b/video-compressor/vendor/ffmpeg-core.js
@@ -1,0 +1,2 @@
+// Placeholder for @ffmpeg/core@0.12.4/dist/umd/ffmpeg-core.js
+// Replace this file with the official distribution build.

--- a/video-compressor/vendor/ffmpeg-core.wasm
+++ b/video-compressor/vendor/ffmpeg-core.wasm
@@ -1,0 +1,2 @@
+Placeholder for @ffmpeg/core@0.12.4/dist/umd/ffmpeg-core.wasm
+Replace this file with the official binary.

--- a/video-compressor/vendor/ffmpeg-core.worker.js
+++ b/video-compressor/vendor/ffmpeg-core.worker.js
@@ -1,0 +1,2 @@
+// Placeholder for @ffmpeg/core@0.12.4/dist/umd/ffmpeg-core.worker.js
+// Replace this file with the official distribution build.

--- a/video-compressor/vendor/ffmpeg.min.mjs
+++ b/video-compressor/vendor/ffmpeg.min.mjs
@@ -1,0 +1,5 @@
+// Placeholder for @ffmpeg/ffmpeg@0.12.4/dist/ffmpeg.min.mjs
+// Replace this file with the official distribution build.
+export const createFFmpeg = () => {
+  throw new Error('FFmpeg assets are missing. Replace vendor/ffmpeg.min.mjs with the @ffmpeg/ffmpeg@0.12.4 dist file.');
+};


### PR DESCRIPTION
### Motivation
- Prevent ESM MIME/CORS errors by serving the ffmpeg module and core files from the same origin instead of a CDN.
- Avoid failed service worker installation and COOP/COEP complexity for the single-threaded compressor UI.
- Provide local placeholders so GitHub Pages can host the required ffmpeg assets alongside the app.

### Description
- Updated `video-compressor/script.js` to import `createFFmpeg` from `./vendor/ffmpeg.min.mjs` instead of the CDN and set `CORE_PATH` to `./vendor/ffmpeg-core.js`.
- Removed the COOP/COEP service worker registration script line (`<script src="../coi-serviceworker.js"></script>`) from `video-compressor/index.html`.
- Added vendor placeholder files at `video-compressor/vendor/ffmpeg.min.mjs`, `video-compressor/vendor/ffmpeg-core.js`, `video-compressor/vendor/ffmpeg-core.wasm`, and `video-compressor/vendor/ffmpeg-core.worker.js` to be replaced with the official distribution artifacts.

### Testing
- No automated tests or CI jobs were run for this change.
- Manual network fetches from the environment failed, so upstream assets were not downloaded and placeholders were added instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964effd38b48325a1f807e30b008fb7)