### PR TITLE
Fix ffmpeg.wasm loading for video compressor

### DIFF
--- a/video-compressor/index.html
+++ b/video-compressor/index.html
@@ -92,6 +92,7 @@
         <p>Powered by <code>ffmpeg.wasm</code>. No videos leave your browser.</p>
     </footer>
 
-    <script type="module" src="script.js"></script>
+    <script src="./vendor/ffmpeg.js"></script>
+    <script type="module" src="./script.js"></script>
 </body>
 </html>

--- a/video-compressor/script.js
+++ b/video-compressor/script.js
@@ -1,4 +1,5 @@
-import { createFFmpeg } from './vendor/ffmpeg.min.mjs';
+// ffmpeg.js is loaded as a UMD script in index.html and exposes global `FFmpeg`
+const { createFFmpeg } = window.FFmpeg;
 
 const startButton = document.getElementById('startButton');
 const fileInput = document.getElementById('videoInput');
@@ -13,7 +14,6 @@ const resultMessage = document.getElementById('resultMessage');
 const uploadStatus = document.getElementById('uploadStatus');
 const uploadStatusText = document.getElementById('uploadStatusText');
 
-const CORE_VERSION = '0.12.4';
 const CORE_PATH = './vendor/ffmpeg-core.js';
 const ffmpeg = createFFmpeg({
   corePath: CORE_PATH,

--- a/video-compressor/vendor/ffmpeg.min.mjs
+++ b/video-compressor/vendor/ffmpeg.min.mjs
@@ -1,5 +1,0 @@
-// Placeholder for @ffmpeg/ffmpeg@0.12.4/dist/ffmpeg.min.mjs
-// Replace this file with the official distribution build.
-export const createFFmpeg = () => {
-  throw new Error('FFmpeg assets are missing. Replace vendor/ffmpeg.min.mjs with the @ffmpeg/ffmpeg@0.12.4 dist file.');
-};


### PR DESCRIPTION
### Motivation

- Ensure ffmpeg.wasm assets load correctly on GitHub Pages by using the local UMD bundle and local core files instead of a CDN/ESM placeholder.
- Prevent the runtime error `FFmpeg assets are missing` caused by the placeholder ESM wrapper.
- Make the page load order explicit so the global UMD `FFmpeg` is available to the module script.

### Description

- Replace the top ESM import in `video-compressor/script.js` with a reference to the global UMD API: `const { createFFmpeg } = window.FFmpeg;`.
- Remove the unused `CORE_VERSION` constant and keep `CORE_PATH` pointing to the local `./vendor/ffmpeg-core.js` used by `createFFmpeg`.
- Load the UMD wrapper before the module script by adding `<script src="./vendor/ffmpeg.js"></script>` before the module tag in `video-compressor/index.html`.
- Delete the placeholder file `video-compressor/vendor/ffmpeg.min.mjs` to avoid confusion with the local UMD bundle.

### Testing

- No automated tests were run for this change.
- Local repository inspections were performed to verify files: checked `video-compressor/vendor` contents and confirmed `ffmpeg.js`, `ffmpeg-core.js`, and `ffmpeg-core.wasm` exist.
- Confirmed modified files: `video-compressor/script.js` and `video-compressor/index.html`, and deletion of `video-compressor/vendor/ffmpeg.min.mjs` via the working tree status.
- Commit created with message `Fix ffmpeg wasm loading for video compressor`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f7ee7e0c83258334214985cc6555)