### PR TITLE
Fix FFmpeg global detection and guard progress listener in video compressor

### DIFF
--- a/video-compressor/script.js
+++ b/video-compressor/script.js
@@ -2,13 +2,14 @@
 const expectedFfmpegScriptUrl = new URL('./vendor/ffmpeg.js', import.meta.url).toString();
 let createFFmpeg;
 let fetchFile;
+const FF = window.FFmpeg || window.FFmpegWASM || window.FFmpegWasm || null;
 
-if (typeof FFmpeg === 'undefined') {
+if (!FF) {
   console.error(
     `FFmpeg UMD build is not available. Ensure the script loaded: ${expectedFfmpegScriptUrl}`,
   );
 } else {
-  ({ createFFmpeg, fetchFile } = FFmpeg);
+  ({ createFFmpeg, fetchFile } = FF);
 }
 
 const startButton = document.getElementById('startButton');
@@ -131,14 +132,16 @@ const getPreset = () => {
   return formData.get('preset');
 };
 
-ffmpeg.on('progress', ({ progress }) => {
-  if (!Number.isFinite(progress)) {
-    return;
-  }
-  progressBar.value = Math.min(1, Math.max(0, progress));
-  const percent = Math.min(100, Math.max(0, Math.round(progress * 100)));
-  progressLabel.textContent = `Compressing… ${percent}%`;
-});
+if (ffmpeg && typeof ffmpeg.on === 'function') {
+  ffmpeg.on('progress', ({ progress }) => {
+    if (!Number.isFinite(progress)) {
+      return;
+    }
+    progressBar.value = Math.min(1, Math.max(0, progress));
+    const percent = Math.min(100, Math.max(0, Math.round(progress * 100)));
+    progressLabel.textContent = `Compressing… ${percent}%`;
+  });
+}
 
 const runCompression = async () => {
   if (!currentFile || isProcessing) {


### PR DESCRIPTION
### Motivation
- The UMD build can expose different globals, so the compressor must accept `FFmpeg` fallbacks like `FFmpegWASM`/`FFmpegWasm` to initialize correctly.
- Attaching the progress listener when the ffmpeg instance is `null` causes a runtime crash when calling `ffmpeg.on('progress', ...)`.
- The compressor should fail gracefully and abort operations early when the ffmpeg engine cannot be created.

### Description
- Updated global detection in `video-compressor/script.js` to use `const FF = window.FFmpeg || window.FFmpegWASM || window.FFmpegWasm || null;` and wire `createFFmpeg`/`fetchFile` from `FF` when present.
- Guarded the progress listener so it only attaches when `ffmpeg` exists and `typeof ffmpeg.on === 'function'` to avoid calling `.on` on `null`.
- Preserved and relied on the existing early-return checks so `runCompression` aborts with a user-facing message when `ffmpeg` is `null`.

### Testing
- No automated tests were run for this change.
- Manual verification steps were not executed as part of the automated rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965549421c083259dd3ce93691c06fb)