### PR TITLE
Fix ffmpeg UMD detection in video compressor

### DIFF
--- a/video-compressor/script.js
+++ b/video-compressor/script.js
@@ -1,8 +1,9 @@
 // ffmpeg.js is loaded as a UMD script in index.html and exposes global `FFmpeg`
 const expectedFfmpegScriptUrl = new URL('./vendor/ffmpeg.js', import.meta.url).toString();
+const getFFmpegUMD = () => window.FFmpeg || window.FFmpegWASM || window.FFmpegWasm || null;
 let createFFmpeg;
 let fetchFile;
-const FF = window.FFmpeg || window.FFmpegWASM || window.FFmpegWasm || null;
+const FF = getFFmpegUMD();
 
 if (!FF) {
   console.error(
@@ -78,14 +79,20 @@ const toggleUploadStatus = (show, text) => {
 };
 
 const ensureFFmpegLoaded = async () => {
-  if (!ffmpeg) {
+  const FF = getFFmpegUMD();
+  if (!FF) {
     console.error(
       `FFmpeg could not initialize because the UMD build is missing. Expected: ${expectedFfmpegScriptUrl}`,
     );
     progressLabel.textContent = 'Unable to load ffmpeg engine.';
     resultMessage.textContent = 'Compression engine failed to load. Please refresh the page.';
+    showEngineLoader(false);
+    toggleUploadStatus(false);
+    startButton.disabled = false;
+    isProcessing = false;
     return;
   }
+  ({ createFFmpeg, fetchFile } = FF);
   if (ffmpegLoaded) {
     return;
   }


### PR DESCRIPTION
### Motivation
- DevTools showed `window.FFmpegWASM` present but the compressor reported the UMD build missing, causing a false-negative detection.
- The goal is to support alternate UMD globals (`FFmpegWASM` / `FFmpegWasm`) and avoid leaving UI loaders spinning when the engine initialization fails.

### Description
- Added helper `getFFmpegUMD()` that returns `window.FFmpeg || window.FFmpegWASM || window.FFmpegWasm || null` and used it for UMD detection.
- Replaced the direct global checks with `getFFmpegUMD()` and rebind `createFFmpeg` and `fetchFile` from the detected UMD object before attempting to load the engine.
- On missing UMD builds, reset UI state by calling `showEngineLoader(false)`, `toggleUploadStatus(false)`, enabling `startButton`, and setting `isProcessing = false` to prevent loaders from spinning indefinitely.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696556e5e130832589c9eccc037314b8)