### PR TITLE
Add Time Frame tool page

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
                 <button class="tab-button" data-tab="device-info" role="tab" aria-selected="false"
                     aria-controls="device-info-panel">Device Details</button>
                 <a href="./video-compressor/" class="tab-button tab-link">Video Compressor</a>
+                <a href="./time-frame/" class="tab-button tab-link">Time Frame</a>
             </div>
         </header>
 

--- a/time-frame/index.html
+++ b/time-frame/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description"
+        content="Track the current week number, year progress, and manage a lightweight countdown timer.">
+    <title>Time Frame · Web Tools Dashboard</title>
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="icon" type="image/svg+xml"
+        href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🛠️</text></svg>">
+</head>
+
+<body>
+    <div class="dashboard-container app-shell page-shell">
+        <header class="page-header">
+            <div class="header-top">
+                <h1>Web Tools Dashboard</h1>
+                <button id="theme-switcher" class="theme-switcher" aria-label="Toggle dark/light theme">
+                    <span class="light-icon" aria-hidden="true">🌞</span>
+                    <span class="dark-icon" aria-hidden="true">🌙</span>
+                </button>
+            </div>
+
+            <div class="tab-navigation" role="tablist">
+                <a href="../#display-tool" class="tab-button tab-link">Display Resolution</a>
+                <a href="../#counter-tool" class="tab-button tab-link">Word Counter</a>
+                <a href="../#case-tool" class="tab-button tab-link">Case Converter</a>
+                <a href="../#clean-text" class="tab-button tab-link">Clean Text</a>
+                <a href="../#device-info" class="tab-button tab-link">Device Details</a>
+                <a href="../video-compressor/" class="tab-button tab-link">Video Compressor</a>
+                <a href="./" class="tab-button tab-link active" aria-current="page">Time Frame</a>
+            </div>
+        </header>
+
+        <div class="tool-panel active time-frame-panel">
+            <h2>Time Frame</h2>
+            <p class="time-frame-intro">Keep track of the current ISO week, year progress, and countdown timers at a glance.</p>
+
+            <div class="time-frame-grid">
+                <div class="info-card time-frame-card">
+                    <h3>Current Week</h3>
+                    <p id="weekNumber">Week 00</p>
+                    <span class="info-subtext" id="weekHint">ISO-8601 week number</span>
+                </div>
+                <div class="info-card time-frame-card">
+                    <h3>Year Progress</h3>
+                    <p id="yearProgressText">0 days 0 hours 0 min elapsed</p>
+                    <div class="time-frame-progress">
+                        <div class="time-frame-progress-fill" id="yearProgressBar" style="width: 0%"></div>
+                    </div>
+                    <span class="info-subtext" id="yearProgressPercent">0% of the year</span>
+                </div>
+            </div>
+
+            <section class="time-frame-timer" aria-labelledby="timerTitle">
+                <div class="time-frame-timer-header">
+                    <div>
+                        <h3 id="timerTitle">Timer</h3>
+                        <p class="time-frame-timer-display" id="timerDisplay">00:30:00</p>
+                        <span class="time-frame-timer-status" id="timerStatus">Ready</span>
+                    </div>
+                </div>
+
+                <div class="time-frame-timer-presets">
+                    <button class="action-btn time-frame-btn" data-duration="1800000">30 min</button>
+                    <button class="action-btn time-frame-btn" data-duration="2700000">45 min</button>
+                    <button class="action-btn time-frame-btn" data-duration="3600000">1 hour</button>
+                </div>
+
+                <div class="time-frame-timer-custom">
+                    <label for="customMinutes">Custom minutes</label>
+                    <div class="time-frame-custom-controls">
+                        <input id="customMinutes" type="number" min="1" max="1440" step="1" placeholder="Enter minutes" />
+                        <button class="action-btn time-frame-btn" id="applyCustom">Set</button>
+                    </div>
+                </div>
+
+                <div class="time-frame-timer-controls">
+                    <button class="action-btn time-frame-btn" id="startTimer">Start</button>
+                    <button class="action-btn time-frame-btn" id="pauseResumeTimer">Pause</button>
+                    <button class="action-btn time-frame-btn" id="resetTimer">Reset</button>
+                </div>
+            </section>
+        </div>
+
+        <footer class="dashboard-footer" aria-label="Application version">Version December 0.0.6 </footer>
+    </div>
+    <script src="script.js"></script>
+</body>
+
+</html>

--- a/time-frame/script.js
+++ b/time-frame/script.js
@@ -1,0 +1,261 @@
+const TIMER_STORAGE_KEY = 'timeFrameTimerState';
+
+function initializeTheme() {
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    document.documentElement.setAttribute('data-theme', savedTheme);
+}
+
+function toggleTheme() {
+    const currentTheme = document.documentElement.getAttribute('data-theme');
+    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', newTheme);
+    localStorage.setItem('theme', newTheme);
+}
+
+initializeTheme();
+
+const themeSwitcher = document.getElementById('theme-switcher');
+if (themeSwitcher) {
+    themeSwitcher.addEventListener('click', toggleTheme);
+}
+
+const weekNumberElement = document.getElementById('weekNumber');
+const yearProgressTextElement = document.getElementById('yearProgressText');
+const yearProgressPercentElement = document.getElementById('yearProgressPercent');
+const yearProgressBarElement = document.getElementById('yearProgressBar');
+
+const timerDisplay = document.getElementById('timerDisplay');
+const timerStatus = document.getElementById('timerStatus');
+const startButton = document.getElementById('startTimer');
+const pauseResumeButton = document.getElementById('pauseResumeTimer');
+const resetButton = document.getElementById('resetTimer');
+const presetButtons = document.querySelectorAll('[data-duration]');
+const customMinutesInput = document.getElementById('customMinutes');
+const applyCustomButton = document.getElementById('applyCustom');
+const timerContainer = document.querySelector('.time-frame-timer');
+
+const defaultTimerState = {
+    durationMs: 1800000,
+    startedAt: null,
+    pausedAt: null,
+    accumulatedPausedMs: 0,
+    isRunning: false
+};
+
+let timerState = { ...defaultTimerState };
+
+function padNumber(value) {
+    return String(value).padStart(2, '0');
+}
+
+function formatTime(ms) {
+    const isNegative = ms < 0;
+    const absoluteMs = Math.abs(ms);
+    const totalSeconds = Math.floor(absoluteMs / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    const formatted = `${padNumber(hours)}:${padNumber(minutes)}:${padNumber(seconds)}`;
+    return isNegative ? `-${formatted}` : formatted;
+}
+
+function getISOWeekNumber(date) {
+    const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    const dayNumber = utcDate.getUTCDay() || 7;
+    utcDate.setUTCDate(utcDate.getUTCDate() + 4 - dayNumber);
+    const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+    const weekNumber = Math.ceil(((utcDate - yearStart) / 86400000 + 1) / 7);
+    return weekNumber;
+}
+
+function updateWeekNumber() {
+    if (!weekNumberElement) return;
+    const weekNumber = getISOWeekNumber(new Date());
+    weekNumberElement.textContent = `Week ${padNumber(weekNumber)}`;
+}
+
+function updateYearProgress() {
+    if (!yearProgressTextElement || !yearProgressPercentElement || !yearProgressBarElement) return;
+    const now = new Date();
+    const startOfYear = new Date(now.getFullYear(), 0, 1);
+    const startOfNextYear = new Date(now.getFullYear() + 1, 0, 1);
+    const elapsedMs = now - startOfYear;
+    const totalMs = startOfNextYear - startOfYear;
+    const percent = Math.min(100, Math.max(0, (elapsedMs / totalMs) * 100));
+
+    const totalMinutes = Math.floor(elapsedMs / 60000);
+    const days = Math.floor(totalMinutes / (60 * 24));
+    const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+    const minutes = totalMinutes % 60;
+
+    yearProgressTextElement.textContent = `${days} days ${hours} hours ${minutes} min elapsed`;
+    yearProgressPercentElement.textContent = `${percent.toFixed(2)}% of the year`;
+    yearProgressBarElement.style.width = `${percent.toFixed(2)}%`;
+}
+
+function loadTimerState() {
+    try {
+        const stored = localStorage.getItem(TIMER_STORAGE_KEY);
+        if (!stored) return;
+        const parsed = JSON.parse(stored);
+        if (typeof parsed.durationMs === 'number') {
+            timerState = {
+                ...defaultTimerState,
+                ...parsed
+            };
+        }
+    } catch (error) {
+        console.error('Failed to load timer state', error);
+    }
+}
+
+function saveTimerState() {
+    localStorage.setItem(TIMER_STORAGE_KEY, JSON.stringify(timerState));
+}
+
+function setDuration(durationMs) {
+    timerState.durationMs = durationMs;
+    timerState.startedAt = null;
+    timerState.pausedAt = null;
+    timerState.accumulatedPausedMs = 0;
+    timerState.isRunning = false;
+    saveTimerState();
+    updateTimerDisplay();
+    updateTimerControls();
+}
+
+function getElapsedMs() {
+    if (!timerState.startedAt) return 0;
+    const now = Date.now();
+    const effectiveNow = timerState.isRunning
+        ? now
+        : (timerState.pausedAt || now);
+    return effectiveNow - timerState.startedAt - timerState.accumulatedPausedMs;
+}
+
+function getRemainingMs() {
+    if (!timerState.startedAt) return timerState.durationMs;
+    return timerState.durationMs - getElapsedMs();
+}
+
+function updateTimerDisplay() {
+    if (!timerDisplay || !timerStatus || !timerContainer) return;
+    const remainingMs = getRemainingMs();
+    timerDisplay.textContent = formatTime(remainingMs);
+
+    const isOverdue = remainingMs < 0;
+    timerContainer.classList.toggle('is-overdue', isOverdue);
+    timerStatus.classList.toggle('overdue', isOverdue);
+
+    if (!timerState.startedAt) {
+        timerStatus.textContent = 'Ready';
+    } else if (!timerState.isRunning && timerState.pausedAt) {
+        timerStatus.textContent = 'Paused';
+    } else if (isOverdue) {
+        timerStatus.textContent = `Overdue by ${formatTime(Math.abs(remainingMs))}`;
+    } else {
+        timerStatus.textContent = 'Running';
+    }
+}
+
+function updateTimerControls() {
+    if (!startButton || !pauseResumeButton || !resetButton) return;
+    const hasStarted = Boolean(timerState.startedAt);
+    startButton.disabled = hasStarted;
+    pauseResumeButton.disabled = !hasStarted;
+    resetButton.disabled = !hasStarted && timerState.durationMs === defaultTimerState.durationMs;
+
+    if (timerState.isRunning) {
+        pauseResumeButton.textContent = 'Pause';
+    } else {
+        pauseResumeButton.textContent = hasStarted ? 'Resume' : 'Pause';
+    }
+}
+
+function startTimer() {
+    if (timerState.startedAt) return;
+    timerState.startedAt = Date.now();
+    timerState.isRunning = true;
+    timerState.pausedAt = null;
+    timerState.accumulatedPausedMs = 0;
+    saveTimerState();
+    updateTimerControls();
+}
+
+function togglePauseResume() {
+    if (!timerState.startedAt) return;
+
+    if (timerState.isRunning) {
+        timerState.isRunning = false;
+        timerState.pausedAt = Date.now();
+    } else {
+        const pauseDuration = timerState.pausedAt ? Date.now() - timerState.pausedAt : 0;
+        timerState.accumulatedPausedMs += pauseDuration;
+        timerState.pausedAt = null;
+        timerState.isRunning = true;
+    }
+
+    saveTimerState();
+    updateTimerControls();
+    updateTimerDisplay();
+}
+
+function resetTimer() {
+    timerState.startedAt = null;
+    timerState.pausedAt = null;
+    timerState.accumulatedPausedMs = 0;
+    timerState.isRunning = false;
+    saveTimerState();
+    updateTimerControls();
+    updateTimerDisplay();
+}
+
+presetButtons.forEach(button => {
+    button.addEventListener('click', () => {
+        const duration = Number(button.dataset.duration);
+        if (!Number.isNaN(duration)) {
+            setDuration(duration);
+        }
+    });
+});
+
+if (applyCustomButton && customMinutesInput) {
+    applyCustomButton.addEventListener('click', () => {
+        const minutes = Number(customMinutesInput.value);
+        if (!Number.isNaN(minutes) && minutes > 0) {
+            setDuration(minutes * 60000);
+            customMinutesInput.value = '';
+        }
+    });
+}
+
+if (startButton) {
+    startButton.addEventListener('click', () => {
+        startTimer();
+        updateTimerDisplay();
+    });
+}
+
+if (pauseResumeButton) {
+    pauseResumeButton.addEventListener('click', togglePauseResume);
+}
+
+if (resetButton) {
+    resetButton.addEventListener('click', resetTimer);
+}
+
+function updateTimer() {
+    updateTimerDisplay();
+}
+
+loadTimerState();
+updateWeekNumber();
+updateYearProgress();
+updateTimerControls();
+updateTimerDisplay();
+
+setInterval(() => {
+    updateWeekNumber();
+    updateYearProgress();
+    updateTimer();
+}, 1000);

--- a/time-frame/styles.css
+++ b/time-frame/styles.css
@@ -1,0 +1,129 @@
+.time-frame-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.time-frame-intro {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.time-frame-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+}
+
+.time-frame-card {
+    min-height: 170px;
+}
+
+.time-frame-progress {
+    width: 100%;
+    height: 10px;
+    background: var(--bg);
+    border-radius: 999px;
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+}
+
+.time-frame-progress-fill {
+    height: 100%;
+    background: var(--accent-color);
+    border-radius: 999px;
+    transition: width 0.4s ease;
+}
+
+.time-frame-timer {
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    background: var(--card);
+    box-shadow: var(--shadow);
+}
+
+.time-frame-timer.is-overdue {
+    background: var(--bg);
+    border-style: dashed;
+}
+
+.time-frame-timer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.time-frame-timer-display {
+    font-size: 2.25rem;
+    font-weight: 600;
+    color: var(--accent-color);
+}
+
+.time-frame-timer-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.time-frame-timer-status.overdue {
+    color: var(--text);
+    font-weight: 600;
+}
+
+.time-frame-timer-presets,
+.time-frame-timer-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 12px;
+}
+
+.time-frame-btn {
+    flex: initial;
+    width: 100%;
+}
+
+.time-frame-timer-custom {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.time-frame-custom-controls {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 12px;
+}
+
+.time-frame-custom-controls input {
+    padding: 12px 16px;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--border-color);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-size: 0.95rem;
+}
+
+.time-frame-custom-controls input:focus {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+    .time-frame-timer-display {
+        font-size: 1.8rem;
+    }
+
+    .time-frame-custom-controls {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained "Time Frame" tool that shows the current ISO-8601 week, year progress with a progress bar, and a persistent countdown timer with presets and overdue indication.

### Description
- Added a new tool page with markup at `time-frame/index.html`, styles at `time-frame/styles.css`, and logic at `time-frame/script.js`, and added a navigation link to the main dashboard in `index.html`.
- Implemented `getISOWeekNumber` for ISO-8601 week calculation, year progress computation between `Jan 1` and next year start (days/hours/minutes + percentage) and a progress bar that updates regularly (1s interval).
- Implemented a countdown timer using `Date.now()` deltas with presets (30/45/60 min), optional custom minutes input, `Start`/`Pause`/`Resume`/`Reset` controls, overtime display (`-HH:MM:SS` and `Overdue` label), and persistence to `localStorage` under the key `timeFrameTimerState` (stores `durationMs`, `startedAt`, `pausedAt`, `accumulatedPausedMs`, `isRunning`).
- Minor UI/behavior tweak: overdue label now displays absolute overdue time (uses `Math.abs` when composing the message).

### Testing
- Started a local HTTP server and loaded `http://127.0.0.1:8000/time-frame/` and captured a headless browser screenshot with Playwright; this automated load+render step succeeded and produced `artifacts/time-frame.png`.
- No unit test suite was run; the automated page load check exercised the new page rendering and basic JS initialization without errors.
- Recommended manual checklist (not automated): switching between tools works; ISO week number spot-check; year progress percent updates; timer presets, pause/resume, negative overtime behavior; refresh restores timer state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a2e362ea483259bb58fa42fd72046)