### PR TITLE
Time Frame: add Clear button, reorder timer controls, fix card spacing, and sync navigation

### DIFF
--- a/time-frame/index.html
+++ b/time-frame/index.html
@@ -39,51 +39,54 @@
             <h2>Time Frame</h2>
             <p class="time-frame-intro">Keep track of the current ISO week, year progress, and countdown timers at a glance.</p>
 
-            <div class="time-frame-grid">
-                <div class="info-card time-frame-card">
-                    <h3>Current Week</h3>
-                    <p id="weekNumber">Week 00</p>
-                    <span class="info-subtext" id="weekHint">ISO-8601 week number</span>
-                </div>
-                <div class="info-card time-frame-card">
-                    <h3>Year Progress</h3>
-                    <p id="yearProgressText">0 days 0 hours 0 min elapsed</p>
-                    <div class="time-frame-progress">
-                        <div class="time-frame-progress-fill" id="yearProgressBar" style="width: 0%"></div>
+            <div class="time-frame-cards">
+                <div class="time-frame-grid">
+                    <div class="info-card time-frame-card">
+                        <h3>Current Week</h3>
+                        <p id="weekNumber">Week 00</p>
+                        <span class="info-subtext" id="weekHint">ISO-8601 week number</span>
                     </div>
-                    <span class="info-subtext" id="yearProgressPercent">0% of the year</span>
+                    <div class="info-card time-frame-card">
+                        <h3>Year Progress</h3>
+                        <p id="yearProgressText">0 days 0 hours 0 min elapsed</p>
+                        <div class="time-frame-progress">
+                            <div class="time-frame-progress-fill" id="yearProgressBar" style="width: 0%"></div>
+                        </div>
+                        <span class="info-subtext" id="yearProgressPercent">0% of the year</span>
+                    </div>
                 </div>
+
+                <section class="time-frame-timer" aria-labelledby="timerTitle">
+                    <div class="time-frame-timer-header">
+                        <div>
+                            <h3 id="timerTitle">Timer</h3>
+                            <p class="time-frame-timer-display" id="timerDisplay">00:30:00</p>
+                            <span class="time-frame-timer-status" id="timerStatus">Ready</span>
+                        </div>
+                    </div>
+
+                    <div class="time-frame-timer-presets">
+                        <button class="action-btn time-frame-btn" data-duration="1800000">30 min</button>
+                        <button class="action-btn time-frame-btn" data-duration="2700000">45 min</button>
+                        <button class="action-btn time-frame-btn" data-duration="3600000">1 hour</button>
+                    </div>
+
+                    <div class="time-frame-timer-custom">
+                        <label for="customMinutes">Custom minutes</label>
+                        <div class="time-frame-custom-controls">
+                            <input id="customMinutes" type="number" min="1" max="1440" step="1" placeholder="Enter minutes" />
+                            <button class="action-btn time-frame-btn" id="applyCustom">Set</button>
+                        </div>
+                    </div>
+
+                    <div class="time-frame-timer-controls">
+                        <button class="action-btn time-frame-btn" id="clearTimer">Clear</button>
+                        <button class="action-btn time-frame-btn" id="resetTimer">Reset</button>
+                        <button class="action-btn time-frame-btn" id="pauseResumeTimer">Pause</button>
+                        <button class="action-btn time-frame-btn" id="startTimer">Start</button>
+                    </div>
+                </section>
             </div>
-
-            <section class="time-frame-timer" aria-labelledby="timerTitle">
-                <div class="time-frame-timer-header">
-                    <div>
-                        <h3 id="timerTitle">Timer</h3>
-                        <p class="time-frame-timer-display" id="timerDisplay">00:30:00</p>
-                        <span class="time-frame-timer-status" id="timerStatus">Ready</span>
-                    </div>
-                </div>
-
-                <div class="time-frame-timer-presets">
-                    <button class="action-btn time-frame-btn" data-duration="1800000">30 min</button>
-                    <button class="action-btn time-frame-btn" data-duration="2700000">45 min</button>
-                    <button class="action-btn time-frame-btn" data-duration="3600000">1 hour</button>
-                </div>
-
-                <div class="time-frame-timer-custom">
-                    <label for="customMinutes">Custom minutes</label>
-                    <div class="time-frame-custom-controls">
-                        <input id="customMinutes" type="number" min="1" max="1440" step="1" placeholder="Enter minutes" />
-                        <button class="action-btn time-frame-btn" id="applyCustom">Set</button>
-                    </div>
-                </div>
-
-                <div class="time-frame-timer-controls">
-                    <button class="action-btn time-frame-btn" id="startTimer">Start</button>
-                    <button class="action-btn time-frame-btn" id="pauseResumeTimer">Pause</button>
-                    <button class="action-btn time-frame-btn" id="resetTimer">Reset</button>
-                </div>
-            </section>
         </div>
 
         <footer class="dashboard-footer" aria-label="Application version">Version December 0.0.6 </footer>

--- a/time-frame/script.js
+++ b/time-frame/script.js
@@ -29,6 +29,7 @@ const timerStatus = document.getElementById('timerStatus');
 const startButton = document.getElementById('startTimer');
 const pauseResumeButton = document.getElementById('pauseResumeTimer');
 const resetButton = document.getElementById('resetTimer');
+const clearButton = document.getElementById('clearTimer');
 const presetButtons = document.querySelectorAll('[data-duration]');
 const customMinutesInput = document.getElementById('customMinutes');
 const applyCustomButton = document.getElementById('applyCustom');
@@ -39,7 +40,8 @@ const defaultTimerState = {
     startedAt: null,
     pausedAt: null,
     accumulatedPausedMs: 0,
-    isRunning: false
+    isRunning: false,
+    isCleared: false
 };
 
 let timerState = { ...defaultTimerState };
@@ -119,6 +121,7 @@ function setDuration(durationMs) {
     timerState.pausedAt = null;
     timerState.accumulatedPausedMs = 0;
     timerState.isRunning = false;
+    timerState.isCleared = false;
     saveTimerState();
     updateTimerDisplay();
     updateTimerControls();
@@ -140,6 +143,13 @@ function getRemainingMs() {
 
 function updateTimerDisplay() {
     if (!timerDisplay || !timerStatus || !timerContainer) return;
+    if (timerState.isCleared) {
+        timerDisplay.textContent = '00:00:00';
+        timerContainer.classList.remove('is-overdue');
+        timerStatus.classList.remove('overdue');
+        timerStatus.textContent = 'Ready';
+        return;
+    }
     const remainingMs = getRemainingMs();
     timerDisplay.textContent = formatTime(remainingMs);
 
@@ -178,6 +188,7 @@ function startTimer() {
     timerState.isRunning = true;
     timerState.pausedAt = null;
     timerState.accumulatedPausedMs = 0;
+    timerState.isCleared = false;
     saveTimerState();
     updateTimerControls();
 }
@@ -205,7 +216,20 @@ function resetTimer() {
     timerState.pausedAt = null;
     timerState.accumulatedPausedMs = 0;
     timerState.isRunning = false;
+    timerState.isCleared = false;
     saveTimerState();
+    updateTimerControls();
+    updateTimerDisplay();
+}
+
+function clearTimer() {
+    timerState.startedAt = null;
+    timerState.pausedAt = null;
+    timerState.accumulatedPausedMs = 0;
+    timerState.isRunning = false;
+    timerState.isCleared = true;
+    localStorage.removeItem(TIMER_STORAGE_KEY);
+    sessionStorage.removeItem(TIMER_STORAGE_KEY);
     updateTimerControls();
     updateTimerDisplay();
 }
@@ -242,6 +266,10 @@ if (pauseResumeButton) {
 
 if (resetButton) {
     resetButton.addEventListener('click', resetTimer);
+}
+
+if (clearButton) {
+    clearButton.addEventListener('click', clearTimer);
 }
 
 function updateTimer() {

--- a/time-frame/styles.css
+++ b/time-frame/styles.css
@@ -16,6 +16,12 @@
     gap: 16px;
 }
 
+.time-frame-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
 .time-frame-card {
     min-height: 170px;
 }

--- a/video-compressor/index.html
+++ b/video-compressor/index.html
@@ -30,6 +30,7 @@
                 <a href="../#clean-text" class="tab-button tab-link">Clean Text</a>
                 <a href="../#device-info" class="tab-button tab-link">Device Details</a>
                 <a href="./" class="tab-button tab-link active" aria-current="page">Video Compressor</a>
+                <a href="../time-frame/" class="tab-button tab-link">Time Frame</a>
             </div>
             <p class="page-intro">Compress mp4 clips right in your browser without uploading them anywhere.<br>The tool uses
                 ffmpeg.wasm and works best for clips up to ~150–200 MB.</p>


### PR DESCRIPTION
### Motivation
- Improve the Time Frame page visual layout so the Timer card no longer sits flush against the info cards and spacing is consistent with other card gaps. 
- Add a non-destructive UI "Clear" action to allow users to immediately stop/reset the timer display and remove persisted state without changing timer business logic. 
- Ensure navigation tab order is identical across Dashboard, Video Compressor and Time Frame pages to avoid missing links and shifting tab order.

### Description
- Introduced a wrapper `.time-frame-cards` and applied a layout-level gap to provide consistent vertical spacing between the week/year cards and the Timer card, matching existing horizontal grid gaps; changed CSS in `time-frame/styles.css` and updated HTML structure in `time-frame/index.html`.
- Reordered timer control buttons in the Timer card to the required left-to-right sequence `Clear`, `Reset`, `Pause`, `Start` and added a new `Clear` button element in `time-frame/index.html`.
- Implemented minimal JS to support the `Clear` action in `time-frame/script.js` by adding `clearTimer()` and a `isCleared` flag, wiring the `#clearTimer` button, clearing `localStorage`/`sessionStorage` for the timer key, stopping the timer, resetting the displayed time to `00:00:00`, clearing overdue styling, and leaving preset/week/year logic intact.
- Added a `Time Frame` link to the Video Compressor header navigation so tab order is preserved across pages by updating `video-compressor/index.html`.
- Files modified: `time-frame/index.html`, `time-frame/styles.css`, `time-frame/script.js`, and `video-compressor/index.html`.

### Testing
- Started a local static server with `python -m http.server 8000` to serve the site and verified the server responded at `http://127.0.0.1:8000/` (server startup succeeded).
- Attempted an automated UI capture using Playwright that navigates to `/time-frame/`, but the headless browser process crashed in this environment so the UI capture failed; no runtime errors were caused by the site code itself.
- No unit tests exist for this UI; manual checklist to validate before merge: `Clear / Reset / Pause / Start`, `Presets still work`, `Refresh after Clear` (persisted state cleared), `Navigation consistency across pages`, and `Mobile layout (narrow viewport)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4b07d674832587849f7d27e4b8db)